### PR TITLE
v0.2.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
-VERSION_NAME=0.2.3
+VERSION_NAME=0.2.4
 GROUP=io.github.dokar3
 
 POM_NAME=sheets


### PR DESCRIPTION
`expand()`, `peek()` and `collapse()` will always suspend the current coroutine until animations are finished