### PR TITLE
Return nested scroll connection on allow outside interaction mode.

### DIFF
--- a/sheets-core/src/commonMain/kotlin/com/dokar/sheets/CoreBottomSheetLayout.kt
+++ b/sheets-core/src/commonMain/kotlin/com/dokar/sheets/CoreBottomSheetLayout.kt
@@ -134,6 +134,7 @@ fun CoreBottomSheetLayout(
 
     Box(
         modifier = Modifier
+            .nestedScroll(nestedScrollConnection)
             .then(
                 if (behaviors.allowOutsideInteraction) {
                     Modifier
@@ -141,7 +142,6 @@ fun CoreBottomSheetLayout(
                     Modifier
                         .fillMaxSize()
                         .drawBehind { drawRect(color = dimColor.copy(alpha = dimAlpha)) }
-                        .nestedScroll(nestedScrollConnection)
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null,


### PR DESCRIPTION
After some tests, I realized that the missing nested scroll leads to the fact that the sheet is not minimized or maximized when the nested list is finished scrolling. Sorry for missing that detail.